### PR TITLE
Fix TERT Promoter issue

### DIFF
--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -224,7 +224,7 @@ conversiondict = {'Ala': 'A',
                   }
 conversionlist = conversiondict.keys()
 def conversion(hgvs):
-    threecharactersearch = re.findall('[a-zA-Z]{3}', hgvs, flags=re.IGNORECASE)
+    threecharactersearch = re.findall('[a-zA-Z]{3}\d+', hgvs, flags=re.IGNORECASE)
     if threecharactersearch:
         if any(letters.lower() in hgvs.lower() for letters in conversionlist):
             return replace_all(hgvs)
@@ -319,7 +319,7 @@ def processalterationevents(eventfile, outfile, previousoutfile, defaultCancerTy
             if hgvs.startswith('p.'):
                 hgvs = hgvs[2:]
             if hugo=='TERT' and (row[iconsequence]=='5\'Flank' or row[iconsequence]=='5\'UTR'):
-                hgvs = "Promoter Mutations"
+                hgvs = "Promoter Mutation"
 
             cancertype = defaultCancerType
             if icancertype >= 0:

--- a/data/example_maf.txt
+++ b/data/example_maf.txt
@@ -12,3 +12,4 @@ RB1	Nonsense_Mutation	TCGA-02-0033-01	p.Q702*	Gln702*
 TP53	Missense_Mutation	TCGA-02-0033-01	p.R248Q	Arg248Gln
 NF1	Splice_Site	TCGA-02-0033-01	p.X1445_splice	X1445_splice
 STK11	Missense_Mutation	TCGA-05-4417-01	p.H168R	His168Arg
+TERT	5'Flank	TCGA-05-4417-01		

--- a/test_Annotation.py
+++ b/test_Annotation.py
@@ -60,11 +60,13 @@ def test_fake_gene_protein_change():
 def test_check_atypical_alts():
     queries = [
         ProteinChangeQuery('Other Biomarkers', 'MSI-H', 'Colorectal Cancer'),
-        ProteinChangeQuery('Other Biomarkers', 'MSI-H', 'Leukemia')
+        ProteinChangeQuery('Other Biomarkers', 'MSI-H', 'Leukemia'),
+        ProteinChangeQuery('TERT', 'Promoter Mutation', 'Bladder Cancer'),
+        ProteinChangeQuery('TERT', 'Promoter Mutation', 'Bladder Cancer', '5\'Flank')
     ]
 
     annotations = pull_mutation_info(queries)
-    assert len(annotations) == 2
+    assert len(annotations) == 4
 
     annotation = get_annotation_from_string(annotations[0])
     assert len(annotation) == 14
@@ -77,6 +79,16 @@ def test_check_atypical_alts():
     assert annotation[MUTATION_EFFECT_INDEX] == UNKNOWN
     assert annotation[ONCOGENIC_INDEX] == 'Oncogenic'
     assert annotation[HIGHEST_LEVEL_INDEX] == ''
+
+    annotation = get_annotation_from_string(annotations[2])
+    assert len(annotation) == 14
+    assert annotation[MUTATION_EFFECT_INDEX] == 'Gain-of-function'
+    assert annotation[ONCOGENIC_INDEX] == 'Oncogenic'
+    assert annotation[HIGHEST_LEVEL_INDEX] == ''
+
+    annotation_dup = get_annotation_from_string(annotations[3])
+    assert len(annotation_dup) == 14
+    assert annotation == annotation_dup
 
 
 @pytest.mark.skipif(ONCOKB_API_TOKEN in (None, ''), reason="oncokb api token required")

--- a/test_AnnotatorCore.py
+++ b/test_AnnotatorCore.py
@@ -31,27 +31,24 @@ def test_getgenesfromfusion():
 
 def test_conversion():
     # Test conversion case for case insensitivity
-    assert conversion('tyr') == 'Y'
-    assert conversion('tYr') == 'Y'
-    assert conversion('Tyr') == 'Y'
-    assert conversion('tyR') == 'Y'
-    assert conversion('TyR') == 'Y'
-    assert conversion('TYR') == 'Y'
-    assert conversion('tYR') == 'Y'
-    assert conversion('sEr') == 'S'
+    assert conversion('tyr100') == 'Y100'
+    assert conversion('tYr100') == 'Y100'
+    assert conversion('Tyr100') == 'Y100'
+    assert conversion('tyR100') == 'Y100'
+    assert conversion('TyR100') == 'Y100'
+    assert conversion('TYR100') == 'Y100'
+    assert conversion('tYR100') == 'Y100'
+    assert conversion('sEr100') == 'S100'
 
     # Test conversion only targets dict() keys
-    assert conversion('hot cup mop lap tap zip Thr cheetos hand') == 'hot cup mop lap tap zip T cheetos hand'
-    assert conversion('Ly s Lys Th r Thr X X As p Asp') == 'Ly s K Th r T X X As p D'
-
-    # Test conversion is not affected by numbers
-    assert conversion('8453 388 830 32 -2 -4 -23 2 -23 6 26 784 1 2 3 4 5 6 7 8 90 0') == '8453 388 830 32 -2 -4 -23 2 -23 6 26 784 1 2 3 4 5 6 7 8 90 0'
-    assert conversion('Val500Thr Asn 788 88 His 5H8is') == 'V500T N 788 88 H 5H8is'
+    assert conversion('hot100') == 'hot100'
 
     # Test conversion is not affected by empty string and whitespaces
     assert conversion('') == ''
-    assert conversion(' ') == ' '
-    assert conversion('Tyr Asn As n Ile Il e') == 'Y N As n I Il e'
+    assert conversion(' sEr100') == ' S100'
+    
+    # Test conversion when the string contains three letter but not supposed to be converted
+    assert conversion('Promoter') == 'Promoter'
 
 def test_replace_all():
     # Test replace_all for case insensitivity


### PR DESCRIPTION
The three letter replacement actually will replace Pro to P in the Promoter Mutations;
Also OncoKB annotate changed to Promoter Mutation without s.