### PR TITLE
Specify kiwisolver version for python 2/3

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,1 @@
 requests==2.20.0
-wheel==0.35.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,1 +1,2 @@
 requests==2.20.0
+wheel=0.35.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,2 @@
 requests==2.20.0
-wheel=0.35.1
+wheel==0.35.1

--- a/requirements/pip2.7.txt
+++ b/requirements/pip2.7.txt
@@ -1,2 +1,3 @@
 matplotlib==2.2.4
 enum34==1.1.10
+kiwisolver==1.1.0

--- a/requirements/pip3.txt
+++ b/requirements/pip3.txt
@@ -1,1 +1,2 @@
 matplotlib==3.1.2
+kiwisolver==1.2.0


### PR DESCRIPTION
The recent version kiwisolver=1.3.0 which will be installed automatically if not installed before has an issue.
This fixes https://github.com/oncokb/oncokb-annotator/issues/108