### PR TITLE
Add retry for annotation endpoints

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,1 +1,2 @@
-requests==2.20.0
+requests==2.27.1
+urllib3==1.26.8


### PR DESCRIPTION
When API returns the following error code or timeout, we should retry the api call.
API response code 429, 500, 502, 503, 504

This fixes https://github.com/oncokb/oncokb-annotator/issues/153