### PR TITLE
Change scripts to pull python version from the env, executable from path

### DIFF
--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import datetime
 import json
 import csv

--- a/ClinicalDataAnnotator.py
+++ b/ClinicalDataAnnotator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import re

--- a/CnaAnnotator.py
+++ b/CnaAnnotator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/FusionAnnotator.py
+++ b/FusionAnnotator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/GenerateReadMe.py
+++ b/GenerateReadMe.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/MafAnnotator.py
+++ b/MafAnnotator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/OncoKBPlots.py
+++ b/OncoKBPlots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import re

--- a/StructuralVariantAnnotator.py
+++ b/StructuralVariantAnnotator.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import argparse

--- a/test_Annotation.py
+++ b/test_Annotation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import pytest
 import os
 import logging

--- a/test_AnnotatorCore.py
+++ b/test_AnnotatorCore.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import pytest
 
 from AnnotatorCore import getgenesfromfusion


### PR DESCRIPTION
Small script changes (the shebang line) to make it easier to execute the .py files from the OS path, default executable mode for the script too. 

This simplifies deploying oncokb-annotator within virtual and conda environments.