### PR TITLE
Typo in mutationtypeconsequencemap ?

### DIFF
--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -126,7 +126,7 @@ pxLevels = [
 
 mutationtypeconsequencemap = {
     '3\'Flank': ['any'],
-    '5\'Flank ': ['any'],
+    '5\'Flank': ['any'],
     'Targeted_Region': ['inframe_deletion', 'inframe_insertion'],
     'COMPLEX_INDEL': ['inframe_deletion', 'inframe_insertion'],
     'ESSENTIAL_SPLICE_SITE': ['feature_truncation'],


### PR DESCRIPTION
Looks like this is a typo in map.  This was found when comparing existing clinical IMPACT annotations derived using MAFAnnotator.py against annotations returned using OncoKB web service directly.  Using script consequence passed to web service is "5'Flank'.  When extra space is removed, consequence becomes 'any'.  The variant is know in the former case, but unknown in the latter case.