### PR TITLE
Set functional fusion to false when annotating intragenic SV

### DIFF
--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -936,7 +936,7 @@ def process_sv(svdata, outfile, previousoutfile, defaultCancerType, cancerTypeMa
             if igeneA < 0 or igeneB < 0:
                 log.warning("Please specify two genes")
                 continue
-            
+
             # SVs will sometimes have only 1 gene (intragenic)
             genes = []
             if (igeneA > -1):
@@ -1568,7 +1568,7 @@ class CNAQuery:
 
 class StructuralVariantQuery:
     # Assume all structural variants in the file are functional fusions unless intragenic
-    def __init__(self, hugoA, hugoB, structural_variant_type, cancertype, is_functional_fusion = True):
+    def __init__(self, hugoA, hugoB, structural_variant_type, cancertype, is_functional_fusion=True):
         if hugoA == hugoB:
             is_functional_fusion = False
             structural_variant_type = 'DELETION'

--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -936,6 +936,13 @@ def process_sv(svdata, outfile, previousoutfile, defaultCancerType, cancerTypeMa
             if igeneA < 0 or igeneB < 0:
                 log.warning("Please specify two genes")
                 continue
+            
+            # SVs will sometimes have only 1 gene (intragenic)
+            genes = []
+            if (igeneA > -1):
+                genes.append(igeneA)
+            if (igeneB > -1):
+                genes.append(igeneB)
 
             svtype = None
             if isvtype >= 0:
@@ -947,7 +954,8 @@ def process_sv(svdata, outfile, previousoutfile, defaultCancerType, cancerTypeMa
 
             cancertype = get_tumor_type_from_row(row, i, defaultCancerType, icancertype, cancerTypeMap, sample)
 
-            sv_query = StructuralVariantQuery(row[igeneA], row[igeneB], svtype, cancertype)
+            # If its only one gene, it's intragenic and thus not a functional fusion
+            sv_query = StructuralVariantQuery(row[igeneA], row[igeneB], svtype, cancertype, len(genes) > 1)
             queries.append(sv_query)
             rows.append(row)
 
@@ -1559,9 +1567,8 @@ class CNAQuery:
 
 
 class StructuralVariantQuery:
-    def __init__(self, hugoA, hugoB, structural_variant_type, cancertype):
-        # Assume all structural variants in the file are functional fusions
-        is_functional_fusion = True
+    # Assume all structural variants in the file are functional fusions unless intragenic
+    def __init__(self, hugoA, hugoB, structural_variant_type, cancertype, is_functional_fusion = True):
         if hugoA == hugoB:
             is_functional_fusion = False
             structural_variant_type = 'DELETION'


### PR DESCRIPTION
Resolves https://github.com/oncokb/oncokb-pipeline/issues/740

Align setting isFunctionalFusion api parameter with CBioPortal and our README:

If SV has only 1 gene, then it is intragenic and set functional fusion to false
Also, [README](https://github.com/oncokb/oncokb-annotator?tab=readme-ov-file#structural-variant:~:text=All%20structural%20variants%20with%20two%20different%20gene%20partners%2C%20they%20will%20be%20considered%20as%20functional%20fusions.) says that we consider SV to be functional fusion by default if it has two different gene partners.
