### PR TITLE
Revert "Add work around for tokens time out"

### DIFF
--- a/AnnotatorCore.py
+++ b/AnnotatorCore.py
@@ -254,7 +254,6 @@ def getOncokbInfo():
 
 
 def validate_oncokb_token():
-    return
     if not oncokb_annotation_api_url.startswith(DEFAULT_ONCOKB_URL):
         log.warning(
             "OncoKB base url has been specified by the user that is different from the default www.oncokb.org. The token validation is skipped.")


### PR DESCRIPTION
This reverts commit 3fc5100554881c925c13f5dac3ec12ba73c8f164.

The infrastructure upgrades seem to have fix this timeout issue.

I'm reverting the work around since it is no longer needed.

Closes https://github.com/oncokb/oncokb-annotator/issues/233